### PR TITLE
Fix/cookie declined bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrivito-another-cookie-banner",
-  "version": "1.1.2",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scrivito-another-cookie-banner",
-      "version": "1.1.2",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrivito-another-cookie-banner",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/Components/CookieDeclinedPlaceholder.js
+++ b/src/Components/CookieDeclinedPlaceholder.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Button } from "react-bootstrap";
+
 import { useCookieConsent } from "./CookieConsentContext";
 import { onKeyAccess } from "../utils/accessibilityHelper";
 
@@ -11,6 +12,7 @@ function CookieDeclinedPlaceholder({
   buttonText,
 }) {
   const { switchDecision } = useCookieConsent();
+
   return (
     <div className="map-container-message cookie-declined-placeholder">
       <div>

--- a/src/Components/CookieGatekeeper.js
+++ b/src/Components/CookieGatekeeper.js
@@ -3,29 +3,29 @@ import { useCookieConsent } from "./CookieConsentContext";
 import CookieDeclinedPlaceholder from "./CookieDeclinedPlaceholder";
 
 function CookieGatekeeper({ children, cookieName }) {
-  const { isAccepted, I18n } = useCookieConsent();
+  const { isAccepted, I18n, hydrated } = useCookieConsent();
 
-  if (!isAccepted(cookieName)) {
-    return (
-      <CookieDeclinedPlaceholder
-        name={cookieName}
-        iconClass={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.iconClass`, {
-          ns: "cookieBanner",
-        })}
-        title={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.title`, {
-          ns: "cookieBanner",
-        })}
-        text={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.text`, {
-          ns: "cookieBanner",
-        })}
-        buttonText={I18n.t("CookieDeclinedPlaceholder.buttonText", {
-          ns: "cookieBanner",
-        })}
-      />
-    );
+  if (hydrated && isAccepted(cookieName)) {
+    return <>{children}</>;
   }
 
-  return <>{children}</>;
+  return (
+    <CookieDeclinedPlaceholder
+      name={cookieName}
+      iconClass={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.iconClass`, {
+        ns: "cookieBanner",
+      })}
+      title={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.title`, {
+        ns: "cookieBanner",
+      })}
+      text={I18n.t(`CookieDeclinedPlaceholder.${cookieName}.text`, {
+        ns: "cookieBanner",
+      })}
+      buttonText={I18n.t("CookieDeclinedPlaceholder.buttonText", {
+        ns: "cookieBanner",
+      })}
+    />
+  );
 }
 
 export default CookieGatekeeper;


### PR DESCRIPTION
Fixes Pivotal [PWS Wohnraumoffensive: Videovorschau im Mini-Format ](https://www.pivotaltracker.com/n/projects/2327151/stories/185414208)

Problem was that the pre-rendered DOM was different from the dynamic content.
The little trick with `React.useEffect` render a copy of the pre-rendered page before checking the cookie consents.
(Deployed on https://eeg-staging.bundesimmo.de/informationen-zur-barrierefreiheit-6c62fda5dcb19485)

https://traviswimer.com/blog/easily-fix-react-hydration-errors/



