### PR TITLE
cookie banner logo and white space CD update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## unreleased
+- [new] [Exchange the BImA Logo in Apps and Websites](https://github.com/infopark-customers/bima-project-webpages-on-scrivito/issues/119)
+
 ## 1.3.2
 - [fix] [Cookie Consent dialog does not pop up, if consent not set of www.bundesimmobilien.de](https://www.pivotaltracker.com/story/show/184081546)
 

--- a/src/assets/cookie_banner.scss
+++ b/src/assets/cookie_banner.scss
@@ -1,16 +1,28 @@
 //***** cookie banner styles*****//
 .modal-dialog {
-  margin: 2% auto;
+  margin: 0 auto;
 }
 .modal-header {
-  padding: 0 1.3rem 0 0;
+  padding: 0 1.1rem 0 0;
   img {
-    height: 4rem;
-    width: auto;
+    height: auto;
+    margin: 25px;
+    width: 180px;
+    @media screen and (min-width: 992px) {
+      margin: 40px;
+      width: 230px;
+    }
+  }
+}
+.modal-body,
+.modal-footer {
+  padding-left: 25px;
+  padding-right: 25px;
+  @media screen and (min-width: 992px) {
+    padding: 30px 40px 15px 40px;
   }
 }
 .modal-body {
-  padding: 1.3rem;
   ul.inline-no-list-type {
     list-style-type: none;
     padding-left: 0;

--- a/src/assets/cookie_banner.scss
+++ b/src/assets/cookie_banner.scss
@@ -19,10 +19,13 @@
   padding-left: 25px;
   padding-right: 25px;
   @media screen and (min-width: 992px) {
-    padding: 30px 40px 15px 40px;
+    padding: 30px 40px 40px;
   }
 }
 .modal-body {
+  @media screen and (max-width: 991px) {
+    padding: 20px 25px;
+  }
   ul.inline-no-list-type {
     list-style-type: none;
     padding-left: 0;

--- a/src/assets/forms.scss
+++ b/src/assets/forms.scss
@@ -586,11 +586,9 @@ form {
 
 //** form modal **//
 .modal-dialog {
-  margin: 5.5rem auto;
   max-width: 95%;
   transform: none !important;
   @media screen and (min-width: 992px) {
-    margin: 1.5rem auto;
     max-width: 80%;
   }
 }


### PR DESCRIPTION
Corporate Design for the Cookie Banner is now updated with these global styles. 

These changes have an affect on the following projects (they have all been tested with these latest changes):
- immobilienportal
- bima internet (homepage)
- pws

Supporting screenshots:
<img width="1224" alt="Screenshot 2025-04-22 at 16 30 03" src="https://github.com/user-attachments/assets/e7660b7d-afa5-454c-ba6d-3ef8bc793848" />
<img width="1255" alt="Screenshot 2025-04-22 at 16 03 15" src="https://github.com/user-attachments/assets/94796211-b16a-4929-9cc5-538bb7a0ac2c" />
<img width="1257" alt="Screenshot 2025-04-22 at 16 03 46" src="https://github.com/user-attachments/assets/4f852d3d-07d3-4f5f-a5ca-8072f4be2877" />
<img width="1258" alt="Screenshot 2025-04-22 at 16 04 42" src="https://github.com/user-attachments/assets/8bb6c533-9007-473d-a530-ad7cc39b9f80" />
<img width="544" alt="Screenshot 2025-04-22 at 16 05 01" src="https://github.com/user-attachments/assets/0f6f6bc4-c94c-48d9-904a-38538017e863" />

